### PR TITLE
Fix macOS package manager's architecture in `latest-pm` endpoint

### DIFF
--- a/examples/example.env
+++ b/examples/example.env
@@ -5,6 +5,9 @@
 # Debugging flag
 RUYI_BACKEND_DEBUG=true
 
+# Reference timezone for the backend service
+RUYI_BACKEND_REF_TIMEZONE="UTC"
+
 # Main Redis connection
 RUYI_BACKEND_CACHE_MAIN__HOST="redis://:password@localhost:6379/0?protocol=3"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1105,15 +1105,15 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpcore2"
-version = "2.10.0"
+version = "2.12.0"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "sys_platform != \"emscripten\""
 files = [
-    {file = "httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01"},
-    {file = "httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc"},
+    {file = "httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb"},
+    {file = "httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648"},
 ]
 
 [package.dependencies]
@@ -1213,31 +1213,31 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "httpx2"
-version = "2.10.0"
+version = "2.12.0"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18"},
-    {file = "httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338"},
+    {file = "httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36"},
+    {file = "httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf"},
 ]
 
 [package.dependencies]
 anyio = {version = ">=4.10", markers = "sys_platform != \"emscripten\""}
-httpcore2 = {version = "2.10.0", markers = "sys_platform != \"emscripten\""}
+httpcore2 = {version = "2.12.0", markers = "sys_platform != \"emscripten\""}
 httpx2-jsfetch = {version = "*", markers = "sys_platform == \"emscripten\" and python_version >= \"3.12\""}
 idna = ">=3.18"
 truststore = {version = ">=0.10", markers = "sys_platform != \"emscripten\""}
 typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 cli = ["click (>=8.4.2)", "pygments (==2.*)", "rich (>=10,<16)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 ws = ["wsproto (>=1.2)"]
-zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
+zstd = ["backports-zstd (>=1.0.0) ; python_version <= \"3.13\""]
 
 [[package]]
 name = "httpx2-jsfetch"
@@ -2551,30 +2551,30 @@ typing-extensions = ">=4.12.2"
 
 [[package]]
 name = "ruff"
-version = "0.16.3"
+version = "0.16.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7"},
-    {file = "ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081"},
-    {file = "ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb"},
-    {file = "ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474"},
-    {file = "ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da"},
-    {file = "ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50"},
-    {file = "ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506"},
-    {file = "ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d"},
-    {file = "ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a"},
-    {file = "ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948"},
-    {file = "ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a"},
-    {file = "ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2"},
+    {file = "ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7"},
+    {file = "ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604"},
+    {file = "ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3"},
+    {file = "ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454"},
+    {file = "ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b"},
+    {file = "ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d"},
+    {file = "ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0"},
+    {file = "ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d"},
+    {file = "ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e"},
+    {file = "ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c"},
+    {file = "ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21"},
+    {file = "ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc"},
 ]
 
 [[package]]
@@ -2807,14 +2807,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"
-version = "0.52.3"
+version = "0.52.4"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c"},
-    {file = "uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58"},
+    {file = "uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1"},
+    {file = "uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2411,6 +2411,18 @@ files = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.3.post1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815"},
+    {file = "pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -2759,6 +2771,18 @@ annotated-doc = ">=0.0.2"
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=13.8.0"
 shellingham = ">=1.3.0"
+
+[[package]]
+name = "types-pytz"
+version = "2026.3.1.20260727"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "types_pytz-2026.3.1.20260727-py3-none-any.whl", hash = "sha256:42ac44e83645bfceb46597342c8fb8ec028a1407e2feae9c5c539986eab6b57a"},
+    {file = "types_pytz-2026.3.1.20260727.tar.gz", hash = "sha256:4364075b6867dd15b210bb8c1d29727d609917129b45600defe1d4b3eda5ecb9"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -3255,4 +3279,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4"
-content-hash = "c8cd4685ac12901a5ea527b4e3073fd26e330c9d528b99b59ccce6838e6b43d9"
+content-hash = "c7e7c2b14564df0e08393c3a3d66955484fbeee6a7209e80b00f341085ef3963"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,22 @@ safe_licenses = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+
+[tool.ruff.lint]
+ignore = [
+  "BLE001",  # catch-alls are needed sometimes
+  "SIM102",  # merging walrus and normal if's can be weird?
+  "SIM103",  # sometimes "if not ...: return False; return True" are the streamlined form
+
+  # ignore some prevalent lints that were silent in ruff < 0.16, for gradual
+  # migration
+  "DTZ001",  # datetime
+  "DTZ005",
+  "I001",  # import ordering
+  "SIM117",  # nested with statements
+  "TRY004",  # prefer TypeError for type errors
+  "UP017",  # datetime.UTC
+  "UP035",  # collections.abc instead of typing
+  "UP040",  # type = instead of TypeAlias (Python 3.12+)
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,11 @@ dependencies = [
   "pydantic (>=2.9.2, <3.0.0)",
   "pydantic-settings (>=2.7.0, <3.0.0)",
   "pyjwt (>=2.10.1,<3.0.0)",
+  "pytz",
   "redis[hiredis] (>=5.2.1,<6.0.0)",
   "semver (>=3.0.4,<4.0.0)",
   "sqlalchemy[aiosqlite,asyncio,asyncmy,postgresql-asyncpg] (>=2.0.36, <3.0.0)",
+  "types-pytz",
 ]
 
 [project.scripts]

--- a/ruyi_backend/app/__init__.py
+++ b/ruyi_backend/app/__init__.py
@@ -1,4 +1,5 @@
-from .root import app as app
+# this ordering is required to avoid circular import issues
+from .root import app as app  # noqa: I001
 
 # register the various API endpoints
 from . import admin as admin

--- a/ruyi_backend/app/__init__.py
+++ b/ruyi_backend/app/__init__.py
@@ -1,5 +1,5 @@
 # this ordering is required to avoid circular import issues
-from .root import app as app  # noqa: I001
+from .root import app as app
 
 # register the various API endpoints
 from . import admin as admin

--- a/ruyi_backend/app/admin.py
+++ b/ruyi_backend/app/admin.py
@@ -150,7 +150,8 @@ async def admin_refresh_pypi_stats(
         new_total = await sum_pypi_download_stats(
             conn,
             date_start=datetime.date(2025, 7, 30),  # our PyPI launch date - 1
-            date_end=datetime.date.today() + datetime.timedelta(days=1),
+            date_end=datetime.datetime.now(tz=cfg.ref_tz).date()
+            + datetime.timedelta(days=1),
             package_name=pkg,
         )
 

--- a/ruyi_backend/app/admin.py
+++ b/ruyi_backend/app/admin.py
@@ -54,7 +54,7 @@ async def admin_process_telemetry(
             ).where(
                 telemetry_raw_uploads.c.created_at >= req.time_start,
                 telemetry_raw_uploads.c.created_at < req.time_end,
-                telemetry_raw_uploads.c.is_processed == False,  # noqa: E712  # DSL usage
+                telemetry_raw_uploads.c.is_processed == False,  # DSL usage
             )
             raw_events: list[ModelTelemetryRawUpload] = []
             upload_ids: list[int] = []

--- a/ruyi_backend/app/admin.py
+++ b/ruyi_backend/app/admin.py
@@ -38,6 +38,7 @@ router = APIRouter(prefix="/admin")
 
 @router.post("/process-telemetry-v1", status_code=204)
 async def admin_process_telemetry(
+    cfg: DIEnvConfig,
     req: ReqProcessTelemetry,
     main_db: DIMainDB,
     es: DIMainES,
@@ -79,13 +80,13 @@ async def admin_process_telemetry(
             # Commit the transaction
             await txn.commit()
 
-    last_processed = datetime.datetime.now(datetime.timezone.utc)
+    last_processed = datetime.datetime.now(tz=cfg.ref_tz)
     await cache.set(KEY_TELEMETRY_DATA_LAST_PROCESSED, last_processed)
 
     # refresh frontend dashboard numbers
     try:
         async with main_db.connect() as conn:
-            await crunch_and_cache_dashboard_numbers(conn, es, cache)
+            await crunch_and_cache_dashboard_numbers(conn, es, cache, cfg.ref_tz)
     except Exception as e:
         # ignore cache errors
         traceback.print_exception(e, file=sys.stderr)
@@ -124,7 +125,7 @@ async def admin_refresh_github_stats(
     # refresh frontend dashboard numbers
     try:
         async with db.connect() as conn:
-            await crunch_and_cache_dashboard_numbers(conn, es, cache)
+            await crunch_and_cache_dashboard_numbers(conn, es, cache, cfg.ref_tz)
     except Exception as e:
         # ignore cache errors
         traceback.print_exception(e, file=sys.stderr)
@@ -162,7 +163,7 @@ async def admin_refresh_pypi_stats(
     # refresh frontend dashboard numbers
     try:
         async with db.connect() as conn:
-            await crunch_and_cache_dashboard_numbers(conn, es, cache)
+            await crunch_and_cache_dashboard_numbers(conn, es, cache, cfg.ref_tz)
     except Exception as e:
         # ignore cache errors
         traceback.print_exception(e, file=sys.stderr)

--- a/ruyi_backend/app/releases.py
+++ b/ruyi_backend/app/releases.py
@@ -88,12 +88,18 @@ def _generate_download_urls(
 ) -> dict[str, list[str]]:
     """Generates download URLs for the given release."""
 
-    return {
-        _platform_key_for_asset_suffix(suffix): _download_urls_for_one_asset(
-            s["tag"], suffix, pm_repo
-        )
-        for suffix in get_supported_asset_suffixes(s)
-    }
+    # Several asset suffixes can map to the same platform key. This happens
+    # during naming transitions, e.g. when the old bare "amd64" and the new
+    # "linux-amd64" assets coexist for the same release. Merge their URLs under
+    # the shared key instead of letting one set clobber the other.
+    result: dict[str, list[str]] = {}
+    for suffix in get_supported_asset_suffixes(s):
+        key = _platform_key_for_asset_suffix(suffix)
+        urls = result.setdefault(key, [])
+        for url in _download_urls_for_one_asset(s["tag"], suffix, pm_repo):
+            if url not in urls:
+                urls.append(url)
+    return result
 
 
 def _get_ide_dl_mirrors(ide_repo: str, ide_slug: str) -> list[str]:

--- a/ruyi_backend/app/releases.py
+++ b/ruyi_backend/app/releases.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Final, cast
+from typing import cast
 
 from fastapi import APIRouter, Response
 import semver
@@ -14,38 +14,54 @@ from ..config.env import DIEnvConfig
 from ..components.github_stats import ReleaseDownloadStats
 from ..components.news_items import NEWS_ITEM_NOT_FOUND, get_news_item_markdown
 from ..schema.releases import LatestReleasesV1, ReleaseDetailV1
+from ..vendored_ruyi.ruyipkg_host import canonicalize_host_str
 
 router = APIRouter(prefix="/releases")
 
-ARCH_NAME_DL_TO_UNAME = {
-    "amd64": "x86_64",
-    "arm64": "aarch64",
+# Aliases for the OS segment of an asset filename suffix that the shared
+# canonicalization logic does not (yet) know about. The onefile distributions
+# for macOS are currently named "<version>.macos-arm64"; this naming is expected
+# to switch to "<version>.darwin-aarch64" later, so both must map to the same
+# canonical "darwin/aarch64" platform key.
+ASSET_SUFFIX_OS_ALIASES = {
+    "macos": "darwin",
 }
 
-ARCH_NAME_UNAME_TO_DL: Final = {v: k for k, v in ARCH_NAME_DL_TO_UNAME.items()}
+
+def _platform_key_for_asset_suffix(suffix: str) -> str:
+    """Canonicalizes an asset filename suffix into a "<os>/<arch>" platform key.
+
+    Bare arch suffixes (e.g. "amd64", "riscv64") imply Linux, while suffixes of
+    the form "<os>-<arch>" (e.g. "macos-arm64") encode a non-Linux OS.
+    """
+
+    os_frag, sep, arch_frag = suffix.partition("-")
+    if sep:
+        os_name = ASSET_SUFFIX_OS_ALIASES.get(os_frag, os_frag)
+        return canonicalize_host_str(f"{os_name}/{arch_frag}")
+    # bare arch; canonicalize_host_str defaults the OS to Linux
+    return canonicalize_host_str(suffix)
 
 
-def get_supported_arches(release_stat: ReleaseDownloadStats) -> list[str]:
-    """Returns the supported architectures for the given release."""
+def get_supported_asset_suffixes(release_stat: ReleaseDownloadStats) -> list[str]:
+    """Returns the platform suffixes of the onefile assets for the release."""
 
     # for now the release assets are named in the following manner:
     #
     # * source archive: ruyi-<version>.tar.gz
-    # * onefile distributions: ruyi-<version>.<arch>
+    # * onefile distributions: ruyi-<version>.<suffix>
     #
-    # with the <arch> currently coinciding with the Debian architecture names
-    # (e.g. amd64 instead of x86_64, arm64 instead of aarch64).
-    #
-    # we can figure out the supported arches for the release this way
-    arches = set()
+    # where <suffix> is either a bare Debian-style arch name (e.g. amd64,
+    # arm64, riscv64) implying Linux, or an "<os>-<arch>" pair for non-Linux
+    # targets (e.g. macos-arm64).
+    suffixes = set()
     for asset in release_stat["assets"]:
         name = asset["name"]
         if name.endswith(".tar.gz"):
             # source archive
             continue
-        arch_dl = name.rsplit(".", 1)[1]
-        arches.add(ARCH_NAME_DL_TO_UNAME.get(arch_dl, arch_dl))
-    return list(sorted(arches))
+        suffixes.add(name.rsplit(".", 1)[1])
+    return list(sorted(suffixes))
 
 
 def get_dl_mirrors(pm_repo: str) -> list[str]:
@@ -58,14 +74,12 @@ def get_dl_mirrors(pm_repo: str) -> list[str]:
     ]
 
 
-# Stub function for download URL generation
 def _download_urls_for_one_asset(
     ver: str,
-    arch: str,
+    suffix: str,
     pm_repo: str,
 ) -> list[str]:
-    arch_dl = ARCH_NAME_UNAME_TO_DL.get(arch, arch)
-    return [base + f"{ver}/ruyi-{ver}.{arch_dl}" for base in get_dl_mirrors(pm_repo)]
+    return [base + f"{ver}/ruyi-{ver}.{suffix}" for base in get_dl_mirrors(pm_repo)]
 
 
 def _generate_download_urls(
@@ -74,11 +88,11 @@ def _generate_download_urls(
 ) -> dict[str, list[str]]:
     """Generates download URLs for the given release."""
 
-    # FIXME: we currently only provide Linux binaries, so the "linux" part is hardcoded
-    # for now
     return {
-        f"linux/{arch}": _download_urls_for_one_asset(s["tag"], arch, pm_repo)
-        for arch in get_supported_arches(s)
+        _platform_key_for_asset_suffix(suffix): _download_urls_for_one_asset(
+            s["tag"], suffix, pm_repo
+        )
+        for suffix in get_supported_asset_suffixes(s)
     }
 
 

--- a/ruyi_backend/app/releases.py
+++ b/ruyi_backend/app/releases.py
@@ -61,7 +61,7 @@ def get_supported_asset_suffixes(release_stat: ReleaseDownloadStats) -> list[str
             # source archive
             continue
         suffixes.add(name.rsplit(".", 1)[1])
-    return list(sorted(suffixes))
+    return sorted(suffixes)
 
 
 def get_dl_mirrors(pm_repo: str) -> list[str]:

--- a/ruyi_backend/app/releases.py
+++ b/ruyi_backend/app/releases.py
@@ -137,7 +137,7 @@ def _get_latest_releases(
     latest_versions_by_channel: dict[str, semver.Version] = {}
     for rel in stats:
         tag = rel["tag"]
-        semver_str = tag[1:] if tag.startswith("v") else tag
+        semver_str = tag.removeprefix("v")
         try:
             v = semver.Version.parse(semver_str)
         except ValueError:

--- a/ruyi_backend/app/releases.py
+++ b/ruyi_backend/app/releases.py
@@ -144,8 +144,10 @@ def _get_latest_releases(
             continue
         channel = "testing" if v.prerelease else "stable"
         try:
-            if v > latest_versions_by_channel[channel]:
-                latest_versions_by_channel[channel] = v
+            latest_versions_by_channel[channel] = max(
+                latest_versions_by_channel[channel],
+                v,
+            )
         except KeyError:
             latest_versions_by_channel[channel] = v
 

--- a/ruyi_backend/app/telemetry.py
+++ b/ruyi_backend/app/telemetry.py
@@ -52,5 +52,3 @@ async def telemetry_pm_upload_v1(payload: UploadPayload, main_db: DIMainDB) -> N
         )
 
         await conn.commit()
-
-    return None

--- a/ruyi_backend/components/frontend_dashboard_processor.py
+++ b/ruyi_backend/components/frontend_dashboard_processor.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 from typing import cast
 
+import pytz
 from elasticsearch import AsyncElasticsearch
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -40,6 +41,7 @@ async def crunch_and_cache_dashboard_numbers(
     db: AsyncConnection,
     es: AsyncElasticsearch,
     cache: CacheStore,
+    tz: pytz.BaseTzInfo,
 ) -> DashboardDataV1:
     """
     Ingests the semi-processed telemetry events to produce statistics for the
@@ -53,7 +55,7 @@ async def crunch_and_cache_dashboard_numbers(
             raise ValueError()
     except Exception:
         # graceful degrade to something sensible
-        last_updated = datetime.datetime.now(datetime.timezone.utc)
+        last_updated = datetime.datetime.now(tz)
 
     gh_org_stats: list[DashboardGitHubOrgStatsV1] = []
     if cached_gh_org_stats_ruyisdk := await cache.get(KEY_GITHUB_ORG_STATS_RUYISDK):
@@ -86,7 +88,7 @@ async def crunch_and_cache_dashboard_numbers(
     pm_pypi_downloads = await cache.get(KEY_PYPI_DOWNLOAD_TOTAL_PM) or 0
 
     # query download counts from ES
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.now(tz=tz)
 
     async def query_es_count(path: str) -> int:
         print(f"querying request counts for path {path} from ES")
@@ -98,7 +100,18 @@ async def crunch_and_cache_dashboard_numbers(
                         {
                             "range": {
                                 "@timestamp": {
-                                    "gte": "2025-01-01T00:00:00+08:00",
+                                    "gte": datetime.datetime(
+                                        2024,
+                                        12,
+                                        31,
+                                        16,
+                                        0,
+                                        0,
+                                        0,
+                                        tzinfo=datetime.UTC,
+                                    )
+                                    .astimezone(tz)
+                                    .isoformat(),  # "2025-01-01T00:00:00+08:00"
                                     "lt": now.isoformat(),
                                 }
                             }

--- a/ruyi_backend/components/frontend_dashboard_processor.py
+++ b/ruyi_backend/components/frontend_dashboard_processor.py
@@ -159,7 +159,7 @@ async def crunch_and_cache_dashboard_numbers(
     other_categories = categories.copy()
     keys_to_remove = []
     for k in other_categories:
-        if k.startswith("pm:") or k.startswith("ide:") or k == "pkg":
+        if k.startswith(("pm:", "ide:")) or k == "pkg":
             keys_to_remove.append(k)
     for k in keys_to_remove:
         del other_categories[k]

--- a/ruyi_backend/components/github_stats.py
+++ b/ruyi_backend/components/github_stats.py
@@ -187,7 +187,7 @@ async def _list_repo_contributors(
     async with debug_lock:
         print(f"{owner}/{repo}: successfully fetched {len(result)} contributor(s)")
 
-    return list(sorted(result))
+    return sorted(result)
 
 
 async def _list_org_members(
@@ -213,7 +213,7 @@ async def _list_org_members(
             page += 1
             continue
         break
-    return list(sorted(result))
+    return sorted(result)
 
 
 async def _list_org_outside_collaborators(
@@ -243,7 +243,7 @@ async def _list_org_outside_collaborators(
             page += 1
             continue
         break
-    return list(sorted(result))
+    return sorted(result)
 
 
 async def query_org_stats(

--- a/ruyi_backend/components/pypi_stats.py
+++ b/ruyi_backend/components/pypi_stats.py
@@ -69,7 +69,7 @@ async def _query_overall(package_name: str) -> list[PyPIStatsDataPoint]:
 
 async def fetch_pypi_download_stats(
     package_name: str,
-) -> dict[datetime.date, int]:
+) -> dict[datetime.datetime, int]:
     """Fetches the download stats for a given PyPI package.
 
     Returns a dictionary containing daily download stats keyed by date.
@@ -78,7 +78,8 @@ async def fetch_pypi_download_stats(
     stats = await _query_overall(package_name)
     result = {}
     for p in stats:
-        dt = datetime.datetime.strptime(p["date"], "%Y-%m-%d").date()
+        y, m, d = map(int, p["date"].split("-"))
+        dt = datetime.datetime(y, m, d, tzinfo=datetime.UTC)
         result[dt] = p["downloads"]
 
     return result
@@ -87,7 +88,7 @@ async def fetch_pypi_download_stats(
 async def persist_pypi_download_stats(
     conn: AsyncConnection,
     package_name: str,
-    stats: dict[datetime.date, int],
+    stats: dict[datetime.datetime, int],
 ) -> None:
     """Persists the given PyPI download stats into the database.
 
@@ -95,12 +96,12 @@ async def persist_pypi_download_stats(
     """
 
     buf: list[ModelDownloadStatsDailyPyPI] = []
-    for date, count in stats.items():
+    for dt, count in stats.items():
         buf.append(
             ModelDownloadStatsDailyPyPI(
                 name=package_name,
                 version="*",
-                date=datetime.datetime(date.year, date.month, date.day),
+                date=dt,
                 count=count,
             ),
         )

--- a/ruyi_backend/config/env.py
+++ b/ruyi_backend/config/env.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, TypeAlias
 from fastapi import Depends
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
+import pytz
 
 from . import defaults
 
@@ -120,6 +121,12 @@ class EnvConfig(BaseSettings, case_sensitive=False):
         nested_model_default_partial_update=True,
     )
     debug: bool = False
+    ref_timezone: str = "UTC"
+
+    @functools.cached_property
+    def ref_tz(self) -> pytz.BaseTzInfo:
+        return pytz.timezone(self.ref_timezone)
+
     auth: AuthConfig = AuthConfig()
     cache_main: RedisConfig = RedisConfig()
     cli: CLIConfig = CLIConfig()

--- a/ruyi_backend/vendored_ruyi/ruyipkg_host.py
+++ b/ruyi_backend/vendored_ruyi/ruyipkg_host.py
@@ -1,0 +1,57 @@
+# https://github.com/ruyisdk/ruyi/blob/5ba0761b0092870cb5996c77e044c6aa731cb44d/ruyi/ruyipkg/host.py
+
+import platform
+import sys
+from typing import NamedTuple
+
+
+class RuyiHost(NamedTuple):
+    os: str
+    arch: str
+
+    def __str__(self) -> str:
+        return f"{self.os}/{self.arch}"
+
+    def canonicalize(self) -> "RuyiHost":
+        return RuyiHost(
+            os=canonicalize_os_str(self.os),
+            arch=canonicalize_arch_str(self.arch),
+        )
+
+
+def canonicalize_host_str(host: str | RuyiHost) -> str:
+    if isinstance(host, str):
+        frags = host.split("/", 1)
+        os = "linux" if len(frags) == 1 else frags[0]
+        arch = frags[0] if len(frags) == 1 else frags[1]
+        return str(RuyiHost(os, arch).canonicalize())
+
+    return str(host.canonicalize())
+
+
+def canonicalize_arch_str(arch: str) -> str:
+    # Information sources:
+    #
+    # * https://bugs.python.org/issue7146#msg94134
+    # * https://superuser.com/questions/305901/possible-values-of-processor-architecture
+    match arch.lower():
+        case "amd64" | "em64t":
+            return "x86_64"
+        case "arm64":
+            return "aarch64"
+        case "x86":
+            return "i686"
+        case arch_lower:
+            return arch_lower
+
+
+def canonicalize_os_str(os: str) -> str:
+    match os:
+        case "win32":
+            return "windows"
+        case _:
+            return os
+
+
+def get_native_host() -> RuyiHost:
+    return RuyiHost(os=sys.platform, arch=platform.machine()).canonicalize()

--- a/tests/test_frontend_dashboard_processor.py
+++ b/tests/test_frontend_dashboard_processor.py
@@ -55,7 +55,12 @@ class FakeCache:
 async def test_dashboard_counts_distinct_installation_report_uuids() -> None:
     db = FakeDB()
 
-    result = await crunch_and_cache_dashboard_numbers(db, FakeES(), FakeCache())
+    result = await crunch_and_cache_dashboard_numbers(
+        db,
+        FakeES(),
+        FakeCache(),
+        datetime.UTC,
+    )
 
     assert result.installs is not None
     assert result.installs.total == 7

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, List, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import msgpack
@@ -22,14 +22,14 @@ from .fixtures import RuyiFileFixtureFactory
 
 
 @pytest.fixture
-def release_stats(ruyi_file: RuyiFileFixtureFactory) -> List[ReleaseDownloadStats]:
+def release_stats(ruyi_file: RuyiFileFixtureFactory) -> list[ReleaseDownloadStats]:
     with ruyi_file.path("github-release-stats-cache.json") as p:
         with open(p, "r") as f:
-            return cast(List[ReleaseDownloadStats], json.load(f))
+            return cast(list[ReleaseDownloadStats], json.load(f))
 
 
-def test_get_latest_releases(release_stats: List[ReleaseDownloadStats]) -> None:
-    stats: List[ReleaseDownloadStats] = release_stats
+def test_get_latest_releases(release_stats: list[ReleaseDownloadStats]) -> None:
+    stats: list[ReleaseDownloadStats] = release_stats
     pm_repo = "foo/bar"
     result: LatestReleasesV1 = _get_latest_releases(
         stats, lambda s: _generate_download_urls(s, pm_repo)

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -150,6 +150,60 @@ def make_ide_release_stats(
     )
 
 
+def test_generate_download_urls_macos_arm64() -> None:
+    pm_repo = "foo/bar"
+    tag = "0.52.0-alpha.20260714"
+    release = make_ide_release_stats(
+        tag,
+        "2026-07-14T10:54:29+00:00",
+        [
+            f"ruyi-{tag}.tar.gz",
+            f"ruyi-{tag}.amd64",
+            f"ruyi-{tag}.arm64",
+            f"ruyi-{tag}.riscv64",
+            f"ruyi-{tag}.macos-arm64",
+        ],
+    )
+    urls = _generate_download_urls(release, pm_repo)
+    assert urls == {
+        "linux/aarch64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.arm64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.arm64",
+        ],
+        "linux/riscv64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.riscv64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.riscv64",
+        ],
+        "linux/x86_64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.amd64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.amd64",
+        ],
+        "darwin/aarch64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.macos-arm64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.macos-arm64",
+        ],
+    }
+
+
+def test_generate_download_urls_darwin_aarch64() -> None:
+    # macos-arm64 asset naming is expected to become darwin-aarch64 later; it
+    # must canonicalize to the same darwin/aarch64 platform key.
+    pm_repo = "foo/bar"
+    tag = "0.53.0"
+    release = make_ide_release_stats(
+        tag,
+        "2026-08-01T00:00:00+00:00",
+        [f"ruyi-{tag}.darwin-aarch64"],
+    )
+    urls = _generate_download_urls(release, pm_repo)
+    assert urls == {
+        "darwin/aarch64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.darwin-aarch64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.darwin-aarch64",
+        ],
+    }
+
+
 def test_generate_ide_download_urls_vscode() -> None:
     ide_repo = "ruyisdk/ruyisdk-vscode-extension"
     ide_slug = "vscode"

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -273,10 +273,8 @@ def test_generate_ide_download_urls_vscode() -> None:
     urls = _generate_ide_download_urls(release, ide_repo, ide_slug)
     assert urls == {
         "none/any": [
-            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/"
-            "0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/"
-            "ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/ruyisdk-vscode-extension-0.1.4.vsix",
         ],
     }
 
@@ -292,10 +290,8 @@ def test_generate_ide_download_urls_eclipse() -> None:
     urls = _generate_ide_download_urls(release, ide_repo, ide_slug)
     assert urls == {
         "none/any": [
-            "https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/download/"
-            "0.1.4/ruyisdk-eclipse-plugins-0.1.4.zip",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/eclipse/"
-            "ruyisdk-eclipse-plugins-0.1.4.zip",
+            "https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/download/0.1.4/ruyisdk-eclipse-plugins-0.1.4.zip",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/eclipse/ruyisdk-eclipse-plugins-0.1.4.zip",
         ],
     }
 
@@ -314,14 +310,10 @@ def test_generate_ide_download_urls_multiple_assets() -> None:
     urls = _generate_ide_download_urls(release, ide_repo, ide_slug)
     assert urls == {
         "none/any": [
-            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/"
-            "0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/"
-            "ruyisdk-vscode-extension-0.1.4.vsix",
-            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/"
-            "0.1.4/ruyisdk-vscode-extension-0.1.4.tar.gz",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/"
-            "ruyisdk-vscode-extension-0.1.4.tar.gz",
+            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/0.1.4/ruyisdk-vscode-extension-0.1.4.tar.gz",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/ruyisdk-vscode-extension-0.1.4.tar.gz",
         ],
     }
 
@@ -357,10 +349,8 @@ def test_get_latest_ide_releases() -> None:
     assert stable.channel == "stable"
     assert stable.download_urls == {
         "none/any": [
-            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/"
-            "0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/"
-            "ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/0.1.4/ruyisdk-vscode-extension-0.1.4.vsix",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/ruyisdk-vscode-extension-0.1.4.vsix",
         ],
     }
 
@@ -369,10 +359,8 @@ def test_get_latest_ide_releases() -> None:
     assert testing.channel == "testing"
     assert testing.download_urls == {
         "none/any": [
-            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/"
-            "0.1.4-beta.1/ruyisdk-vscode-extension-0.1.4-beta.1.vsix",
-            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/"
-            "ruyisdk-vscode-extension-0.1.4-beta.1.vsix",
+            "https://github.com/ruyisdk/ruyisdk-vscode-extension/releases/download/0.1.4-beta.1/ruyisdk-vscode-extension-0.1.4-beta.1.vsix",
+            "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/vscode/ruyisdk-vscode-extension-0.1.4-beta.1.vsix",
         ],
     }
 
@@ -416,8 +404,6 @@ def test_latest_eclipse_with_v_prefixed_tags() -> None:
     assert stable.version == "0.1.4"
     assert stable.channel == "stable"
     assert stable.download_urls["none/any"] == [
-        "https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/download/"
-        "v0.1.4/ruyisdk-eclipse-plugins-0.1.4.zip",
-        "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/eclipse/"
-        "ruyisdk-eclipse-plugins-0.1.4.zip",
+        "https://github.com/ruyisdk/ruyisdk-eclipse-plugins/releases/download/v0.1.4/ruyisdk-eclipse-plugins-0.1.4.zip",
+        "https://mirror.iscas.ac.cn/ruyisdk/ide/plugins/eclipse/ruyisdk-eclipse-plugins-0.1.4.zip",
     ]

--- a/tests/test_releases.py
+++ b/tests/test_releases.py
@@ -204,6 +204,64 @@ def test_generate_download_urls_darwin_aarch64() -> None:
     }
 
 
+def test_generate_download_urls_linux_prefixed_suffix() -> None:
+    # Linux onefile assets are expected to gain a "linux-" prefix later; the
+    # new naming must produce the same linux/<arch> platform keys.
+    pm_repo = "foo/bar"
+    tag = "0.60.0"
+    release = make_ide_release_stats(
+        tag,
+        "2026-09-01T00:00:00+00:00",
+        [
+            f"ruyi-{tag}.tar.gz",
+            f"ruyi-{tag}.linux-amd64",
+            f"ruyi-{tag}.linux-arm64",
+            f"ruyi-{tag}.linux-riscv64",
+        ],
+    )
+    urls = _generate_download_urls(release, pm_repo)
+    assert urls == {
+        "linux/aarch64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.linux-arm64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.linux-arm64",
+        ],
+        "linux/riscv64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.linux-riscv64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.linux-riscv64",
+        ],
+        "linux/x86_64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.linux-amd64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.linux-amd64",
+        ],
+    }
+
+
+def test_generate_download_urls_merges_old_and_new_naming() -> None:
+    # During the rename transition a release may carry both the old bare arch
+    # name and the new "linux-<arch>" name for the same platform. Both map to
+    # the same platform key, and their URLs must be merged rather than one set
+    # silently dropped.
+    pm_repo = "foo/bar"
+    tag = "0.61.0"
+    release = make_ide_release_stats(
+        tag,
+        "2026-10-01T00:00:00+00:00",
+        [
+            f"ruyi-{tag}.amd64",
+            f"ruyi-{tag}.linux-amd64",
+        ],
+    )
+    urls = _generate_download_urls(release, pm_repo)
+    assert urls == {
+        "linux/x86_64": [
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.amd64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.amd64",
+            f"https://github.com/foo/bar/releases/download/{tag}/ruyi-{tag}.linux-amd64",
+            f"https://mirror.iscas.ac.cn/ruyisdk/ruyi/tags/{tag}/ruyi-{tag}.linux-amd64",
+        ],
+    }
+
+
 def test_generate_ide_download_urls_vscode() -> None:
     ide_repo = "ruyisdk/ruyisdk-vscode-extension"
     ide_slug = "vscode"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 
 import pytest
 from fastapi.testclient import TestClient
@@ -49,7 +49,7 @@ class FakeConnection:
         self.executions: list[tuple[str, dict[str, Any]]] = []
         self.committed = False
 
-    async def __aenter__(self) -> "FakeConnection":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(


### PR DESCRIPTION
Fixes #113

## Summary by Sourcery

Fix latest package manager download metadata by canonicalizing release asset platforms and correctly identifying macOS architectures.

New Features:
- Support macOS and future OS-prefixed release assets in the latest package manager release download metadata.

Bug Fixes:
- Correct the architecture and platform keys exposed for macOS package manager downloads.
- Preserve download URLs when legacy and new asset naming conventions coexist.

Enhancements:
- Centralize host and architecture canonicalization for release asset platform mapping.
- Add configurable reference timezone handling for dashboard and administrative statistics processing.

Build:
- Add timezone dependencies and Ruff lint configuration.

Tests:
- Add coverage for macOS, Darwin, Linux-prefixed, and mixed release asset naming conventions.